### PR TITLE
Fix HDI Rendering in Rich Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdclipboardext",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "type": "module",
   "scripts": {
     "dev": "tsc --sourceMap --inlineSources && vite build --sourcemap=inline",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "__MSG_appDesc__",
   "permissions": ["storage", "clipboardRead", "clipboardWrite"],
   "default_locale": "en",

--- a/src/options.css
+++ b/src/options.css
@@ -13,6 +13,19 @@ body {
   --text-sm: 1rem;
   --text-xs: 0.875rem;
   --text-xxs: 0.75rem;
+  
+  /* Force inheritance of our up-scaled var into Lexical's contenteditable */
+  font-size: var(--text-base);
+}
+
+/* 
+ * Lexical's contentEditable hardcodes padding to 12px. 
+ * Override with scaled `rem` units to prevent the boundaries from feeling 
+ * disproportionately tight when text scales up on High-DPI displays.
+ */
+.mdxeditor-fullscreen [contenteditable="true"].mdxeditor-root-contenteditable,
+.mdxeditor-fullscreen [data-lexical-editor="true"] {
+  padding: 1rem !important;
 }
 
 .help-button {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,12 +29,15 @@ export function htmlToMarkdown(htmlString: string): string {
   const mdast = toMdast(hast);
 
   // Serialize MDAST to Markdown string
-  const markdown = toMarkdown(mdast, {
+  let markdown = toMarkdown(mdast, {
     extensions: [gfmToMarkdown(), directiveToMarkdown()],
     bullet: "-",
     emphasis: "_",
     ruleSpaces: true,
   });
+
+  // Remove empty directives
+  markdown = markdown.replace(/<!---->\n/g, "\n");
 
   return markdown;
 }


### PR DESCRIPTION
## 1. Type of Change
[X] Bug Fix | [ ] Enhancement | [ ] Maintenance | [ ] Refactor

## 2. Objective
Resolve High-DPI text scaling issues within MDXEditor and clean up empty HTML comments that were leaking into the markdown output.

## 3. Implementation Summary
- Enforced font-size inheritance in `src::options.css` for Lexical's `contenteditable` component using the `--text-base` variable.
- Replaced hardcoded padding on the editor root with relative `rem` units to ensure proportional scaling on high-DPI displays.
- Added a step to strip empty directive artifacts (`<!---->`) from the serialized markdown string in `src::utils.ts`.
- Bumped the extension version from 1.0.9 to 1.0.10 in `package.json` and `public::manifest.json`.

## 4. Architectural Impact & Risk
* **Performance/Security**: No measurable impact. Overrides are limited to CSS specificity fixes and a single regex string replacement.
* **Edge Cases Handled**: Accounts for arbitrary empty html comments/directives incorrectly mapped by the unified/mdast HTML-to-Markdown processor.

## 5. Verification
- Manual verification of proportional UI scaling and readability within the options page on high-density displays.
- Verified that empty HTML comments are now reliably discarded in the generated markdown text.