### PR TITLE
Refine markdown string normalization for empty directives

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,7 @@ export function htmlToMarkdown(htmlString: string): string {
   });
 
   // Remove empty directives
-  markdown = markdown.replace(/<!---->\n/g, "\n");
+  markdown = markdown.replace(/<!---->/g, "").replace(/\n{3,}/g, "\n\n");
 
   return markdown;
 }


### PR DESCRIPTION
## 1. Type of Change
[x] Bug Fix | [ ] Enhancement | [ ] Maintenance | [ ] Refactor

## 2. Objective
To improve the reliability of markdown string generation by consistently stripping out empty HTML directives and cleaning up any resulting excessive vertical whitespace.

## 3. Implementation Summary
- Updated regex in `src::utils.ts` to remove all isolated `<!---->` strings rather than only those followed by a newline.
- Appended a normalization replace cycle to collapse 3 or more consecutive newlines down to a standard double newline (`\n\n`).

## 4. Architectural Impact & Risk
* **Performance/Security**: No measurable impact.
* **Edge Cases Handled**: Solves the edge case where an empty HTML directive occurs inline or at EOF without a concluding newline, and standardizes spacing across multiple generated text blocks.

## 5. Verification
- No tests required - static regex fix for formatting.