### PR TITLE
v1.1.11 Implement split action bar for Markdown and Clean HTML conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdclipboardext",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.1.11",
   "type": "module",
   "scripts": {
     "dev": "tsc --sourceMap --inlineSources && vite build -c vite.popup.config.ts --sourcemap=inline && vite build -c vite.options.config.ts --sourcemap=inline",
@@ -15,10 +15,12 @@
   "dependencies": {
     "@mdxeditor/editor": "^3.52.5",
     "hast-util-from-html": "^2.0.3",
+    "hast-util-to-html": "^9.0.0",
     "hast-util-to-mdast": "^10.1.2",
     "mdast-util-directive": "^3.1.0",
     "mdast-util-from-markdown": "^2.0.3",
     "mdast-util-gfm": "^3.1.0",
+    "mdast-util-to-hast": "^13.0.0",
     "mdast-util-to-markdown": "^2.1.2",
     "micromark-extension-directive": "^4.0.0",
     "react": "^19.2.4",

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "Markdown in die Zwischenablage kopiert!"
   },
+  "notifySuccessHtml": {
+    "message": "Vereinfachte Formatierung in die Zwischenablage kopiert!"
+  },
   "notifyErrorPrefix": {
     "message": "Konnte Zwischenablage nicht verarbeiten."
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "Vollbild-Editor öffnen"
+  },
+  "actionToMarkdownBtn": {
+    "message": "Zu Markdown"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "Zwischenablage in Markdown-Text konvertieren"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "Vereinfacht kopieren"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "Zwischenablage in vereinfachte Formatierung konvertieren"
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -59,6 +59,10 @@
     "message": "Markdown copied to clipboard!",
     "description": "Success notification"
   },
+  "notifySuccessHtml": {
+    "message": "Simplified formatting copied to clipboard!",
+    "description": "Success notification for HTML conversion"
+  },
   "notifyErrorPrefix": {
     "message": "Couldn't process clipboard.",
     "description": "Error notification prefix"
@@ -186,5 +190,21 @@
   "popOutBtn": {
     "message": "Open full editor",
     "description": "Label for the pop-out button"
+  },
+  "actionToMarkdownBtn": {
+    "message": "To Markdown",
+    "description": "Button to convert clipboard into Markdown text"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "Convert clipboard contents to Markdown text",
+    "description": "Tooltip for the To Markdown button"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "Copy Simplified",
+    "description": "Button to convert clipboard into simple formatted text"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "Convert clipboard contents to simplified formatting",
+    "description": "Tooltip for the To Clean HTML button"
   }
 }

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "¡Markdown copiado al portapapeles!"
   },
+  "notifySuccessHtml": {
+    "message": "¡Formato simplificado copiado al portapapeles!"
+  },
   "notifyErrorPrefix": {
     "message": "No se pudo procesar el portapapeles."
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "Abrir editor completo"
+  },
+  "actionToMarkdownBtn": {
+    "message": "A Markdown"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "Convertir el contenido del portapapeles a texto Markdown"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "Copiar simplificado"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "Convertir el contenido del portapapeles a formato simplificado"
   }
 }

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "Markdown copié dans le presse-papiers !"
   },
+  "notifySuccessHtml": {
+    "message": "Mise en forme simplifiée copiée dans le presse-papiers !"
+  },
   "notifyErrorPrefix": {
     "message": "Impossible de traiter le presse-papiers."
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "Ouvrir l'éditeur complet"
+  },
+  "actionToMarkdownBtn": {
+    "message": "Vers Markdown"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "Convertir le contenu du presse-papiers en texte Markdown"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "Copier simplifié"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "Convertir le contenu du presse-papiers avec une mise en forme simplifiée"
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "Markdownをクリップボードにコピーしました！"
   },
+  "notifySuccessHtml": {
+    "message": "シンプルな書式でクリップボードにコピーされました！"
+  },
   "notifyErrorPrefix": {
     "message": "クリップボードを処理できませんでした。"
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "フルエディタを開く"
+  },
+  "actionToMarkdownBtn": {
+    "message": "Markdownへ"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "クリップボードの内容をMarkdownテキストに変換"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "シンプルにコピー"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "クリップボードの内容をシンプルな書式に変換"
   }
 }

--- a/public/_locales/pt_BR/messages.json
+++ b/public/_locales/pt_BR/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "Markdown copiado para a área de transferência!"
   },
+  "notifySuccessHtml": {
+    "message": "Formatação simplificada copiada para a área de transferência!"
+  },
   "notifyErrorPrefix": {
     "message": "Não foi possível processar a área de transferência."
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "Abrir editor completo"
+  },
+  "actionToMarkdownBtn": {
+    "message": "Para Markdown"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "Converter o conteúdo da área de transferência para texto Markdown"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "Copiar Simplificado"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "Converter o conteúdo da área de transferência para formatação simplificada"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -44,6 +44,9 @@
   "notifySuccess": {
     "message": "Markdown 已复制到剪贴板！"
   },
+  "notifySuccessHtml": {
+    "message": "简化格式已复制到剪贴板！"
+  },
   "notifyErrorPrefix": {
     "message": "无法处理剪贴板内容。"
   },
@@ -139,5 +142,17 @@
   },
   "popOutBtn": {
     "message": "打开完整编辑器"
+  },
+  "actionToMarkdownBtn": {
+    "message": "转为 Markdown"
+  },
+  "actionToMarkdownTooltip": {
+    "message": "将剪贴板内容转换为 Markdown 文本"
+  },
+  "actionToCleanHtmlBtn": {
+    "message": "复制简化格式"
+  },
+  "actionToCleanHtmlTooltip": {
+    "message": "将剪贴板内容转换为简化格式"
   }
 }

--- a/public/clearFormattingIcon.svg
+++ b/public/clearFormattingIcon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Capital T for text -->
+  <path d="M4 7V4h12v3"></path>
+  <path d="M10 4v16"></path>
+  <path d="M6 20h8"></path>
+  <!-- Small x for clear/remove -->
+  <line x1="16" y1="16" x2="22" y2="22"></line>
+  <line x1="22" y1="16" x2="16" y2="22"></line>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.0.10",
+  "version": "1.1.11",
   "description": "__MSG_appDesc__",
   "permissions": ["storage", "clipboardRead", "clipboardWrite"],
   "default_locale": "en",

--- a/src/popup.css
+++ b/src/popup.css
@@ -40,18 +40,35 @@ button {
   transition: background-color 0.2s, opacity 0.2s;
 }
 
-.primary-action-btn {
-  background-color: #d67b36;
-  color: white;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem;
-  font-weight: bold;
-  align-self: flex-start;
+.split-action-bar {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
   margin-bottom: 1rem;
 }
 
-.primary-action-btn:hover {
+.split-action-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background-color: #d67b36;
+  color: white;
+  padding: 0.6rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: bold;
+  text-align: center;
+}
+
+.split-action-btn:hover {
   background-color: #c46d2c;
+}
+
+.split-action-icon {
+  width: 20px;
+  height: 20px;
 }
 
 .modifiedTextArea {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { htmlToMarkdown, isMarkdownText } from "./utils";
+import { htmlToMarkdown, markdownToCleanHtml } from "./utils";
 
 import openIconSrc from "../public/openNewWindowIcon.svg";
 import clearIconSrc from "../public/clearbutton.svg";
+import appIconSrc from "../public/icon48.png";
+import clearFormatIconSrc from "../public/clearFormattingIcon.svg";
 import "./popup.css";
 
 const Popup: React.FC = () => {
@@ -72,89 +74,64 @@ const Popup: React.FC = () => {
     });
   }, []);
 
-  const handleCopyModifyPaste = async (): Promise<void> => {
+  const handleConversion = async (targetFormat: "markdown" | "cleanHtml"): Promise<void> => {
     try {
       const clipboardContents = await navigator.clipboard.read();
+      
+      let sourceMarkdown = "";
+      let hasHtml = false;
+      let hasMarkdownFromSession = false;
 
-      // Helper function to handle markdown display (without clipboard write)
-      const displayMarkdown = (markdownText: string): void => {
-        setModifiedText(markdownText);
-        chrome.storage.session.set({ currentMarkdown: markdownText }, () => {
-          showNotificationMsg(
-            chrome.i18n.getMessage("notifyMarkdownDetected"),
-          );
-          handleSave(markdownText);
-        });
-      };
+      // Extract HTML text if present
+      const clipboardHtmlItem = clipboardContents.find((s) => s.types.includes("text/html"));
+      if (clipboardHtmlItem) {
+        const blob = await clipboardHtmlItem.getType("text/html");
+        const htmlText = (await blob?.text()) ?? "";
+        if (htmlText) {
+          hasHtml = true;
+          sourceMarkdown = htmlToMarkdown(htmlText);
+        }
+      }
 
-      // Check for markdown MIME types first
-      const markdownItem = clipboardContents.find(
-        (s) =>
-          s.types.includes("text/markdown") ||
-          s.types.includes("text/x-markdown"),
-      );
-      if (markdownItem) {
-        const markdownType =
-          markdownItem.types.find((t) => t.includes("markdown")) ??
-          "text/plain";
-        const blob = await markdownItem.getType(markdownType);
-        const markdownText = (await blob?.text()) ?? "";
-        if (markdownText) {
-          displayMarkdown(markdownText);
+      // If no valid HTML found, rely solely on our existing session state
+      if (!hasHtml) {
+        if (modifiedText.trim() && modifiedText !== chrome.i18n.getMessage("notifyNoRichTextDetails") && modifiedText !== chrome.i18n.getMessage("notifyNoTextDetails")) {
+          hasMarkdownFromSession = true;
+          sourceMarkdown = modifiedText;
+        } else {
+          showNotificationMsg(chrome.i18n.getMessage("notifyNoRichText"));
+          setModifiedText(chrome.i18n.getMessage("notifyNoRichTextDetails"));
           return;
         }
       }
 
-      // Check for HTML
-      const clipboardItem = clipboardContents.find((s) =>
-        s.types.includes("text/html"),
-      );
-      if (!clipboardItem) {
-        // Check if plain text is markdown
-        const plainTextItem = clipboardContents.find((s) =>
-          s.types.includes("text/plain"),
-        );
-        if (plainTextItem) {
-          const blob = await plainTextItem.getType("text/plain");
-          const plainText = (await blob?.text()) ?? "";
-          if (plainText && isMarkdownText(plainText)) {
-            displayMarkdown(plainText);
-            return;
-          }
-        }
-        showNotificationMsg(
-          chrome.i18n.getMessage("notifyAlreadyConverted"),
-        );
-        return;
-      }
-      const blob = await clipboardItem.getType("text/html");
-      const htmlText = (await blob?.text()) ?? "";
-
-      if (htmlText === "") {
+      if (!sourceMarkdown.trim()) {
         showNotificationMsg(chrome.i18n.getMessage("notifyNoRichText"));
-        setModifiedText(
-          chrome.i18n.getMessage("notifyNoRichTextDetails"),
-        );
+        setModifiedText(chrome.i18n.getMessage("notifyNoTextDetails"));
         return;
       }
 
-      // --- Convert HTML to Markdown ---
-      const markdownText = htmlToMarkdown(htmlText);
-      if (markdownText === "") {
-        showNotificationMsg(chrome.i18n.getMessage("notifyNoRichText"));
-        setModifiedText(
-          chrome.i18n.getMessage("notifyNoTextDetails"),
-        );
-        return;
+      // 1. Text area should ONLY show markdown
+      setModifiedText(sourceMarkdown);
+
+      // 2. Output to clipboard based on targetFormat
+      if (targetFormat === "markdown") {
+        await navigator.clipboard.writeText(sourceMarkdown);
+      } else {
+        const cleanHtmlText = markdownToCleanHtml(sourceMarkdown);
+        const outputBlob = new Blob([cleanHtmlText], { type: "text/html" });
+        const plainBlob = new Blob([sourceMarkdown], { type: "text/plain" });
+        const item = new ClipboardItem({
+          "text/html": outputBlob,
+          "text/plain": plainBlob
+        });
+        await navigator.clipboard.write([item]);
       }
 
-      setModifiedText(markdownText);
-      await navigator.clipboard.writeText(markdownText);
-      chrome.storage.session.set({ currentMarkdown: markdownText }, () => {
-        showNotificationMsg(
-          chrome.i18n.getMessage("notifySuccess"),
-        );
-        handleSave(markdownText);
+      chrome.storage.session.set({ currentMarkdown: sourceMarkdown }, () => {
+        const successMessageKey = targetFormat === "markdown" ? "notifySuccess" : "notifySuccessHtml";
+        showNotificationMsg(chrome.i18n.getMessage(successMessageKey));
+        handleSave(sourceMarkdown);
       });
     } catch (err) {
       console.error("Failed to read/write clipboard:", err);
@@ -176,9 +153,24 @@ const Popup: React.FC = () => {
       <main className="main-content">
         <h1>{chrome.i18n.getMessage("popupTitle")}</h1>
         <p>{chrome.i18n.getMessage("popupSubtitle")}</p>
-        <button className="primary-action-btn" onClick={handleCopyModifyPaste}>
-          {chrome.i18n.getMessage("modifyClipboardBtn")}
-        </button>
+        <div className="split-action-bar">
+          <button 
+            className="split-action-btn" 
+            onClick={() => handleConversion("markdown")}
+            title={chrome.i18n.getMessage("actionToMarkdownTooltip")}
+          >
+            <img src={appIconSrc} alt="" className="split-action-icon" />
+            {chrome.i18n.getMessage("actionToMarkdownBtn") || "To Markdown"}
+          </button>
+          <button 
+            className="split-action-btn" 
+            onClick={() => handleConversion("cleanHtml")}
+            title={chrome.i18n.getMessage("actionToCleanHtmlTooltip")}
+          >
+            <img src={clearFormatIconSrc} alt="" className="split-action-icon" />
+            {chrome.i18n.getMessage("actionToCleanHtmlBtn") || "To Clean HTML"}
+          </button>
+        </div>
         <textarea
           ref={textareaRef}
           className="modifiedTextArea"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import { fromHtml } from "hast-util-from-html";
 import { toMarkdown } from "mdast-util-to-markdown";
 import { toMdast } from "hast-util-to-mdast";
+import { toHast } from "mdast-util-to-hast";
+import { toHtml } from "hast-util-to-html";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { gfmToMarkdown, gfmFromMarkdown } from "mdast-util-gfm";
 import { directive } from "micromark-extension-directive";
@@ -84,4 +86,67 @@ export function isMarkdownText(text: string): boolean {
     console.log(error);
     return false;
   }
+}
+
+/**
+ * Converts an HTML string into Clean Basic HTML.
+ * Uses the MDAST pipeline to strip out bloat.
+ *
+ * @param htmlString The bloated HTML string to clean.
+ * @returns Clean, simplified HTML string.
+ */
+export function htmlToCleanHtml(htmlString: string): string {
+  if (!htmlString || htmlString.trim() === "") {
+    return "";
+  }
+
+  // Parse HTML into HAST (Hypertext Abstract Syntax Tree)
+  const hast = fromHtml(htmlString, { fragment: true });
+
+  // Transform HAST to MDAST (Markdown Abstract Syntax Tree) to strip bloat
+  const mdast = toMdast(hast);
+
+  // Transform MDAST back to HAST (Clean HAST)
+  // Disable common behaviors that might inject positional or unneeded data if necessary
+  const cleanHast = toHast(mdast);
+
+  if (!cleanHast) {
+    return "";
+  }
+
+  // Serialize Clean HAST to HTML string
+  const cleanHtml = toHtml(cleanHast as Parameters<typeof toHtml>[0]);
+
+  return cleanHtml;
+}
+
+/**
+ * Converts a Markdown string into Clean Basic HTML.
+ * Uses the MDAST pipeline.
+ *
+ * @param markdown The Markdown string.
+ * @returns Clean, simplified HTML string.
+ */
+export function markdownToCleanHtml(markdown: string): string {
+  if (!markdown || markdown.trim() === "") {
+    return "";
+  }
+
+  // Parse Markdown into MDAST
+  const mdast = fromMarkdown(markdown, {
+    extensions: [directive()],
+    mdastExtensions: [gfmFromMarkdown(), directiveFromMarkdown()]
+  });
+
+  // Transform MDAST to HAST (Clean HAST)
+  const cleanHast = toHast(mdast);
+
+  if (!cleanHast) {
+    return "";
+  }
+
+  // Serialize Clean HAST to HTML string
+  const cleanHtml = toHtml(cleanHast as Parameters<typeof toHtml>[0]);
+
+  return cleanHtml;
 }


### PR DESCRIPTION
## 1. Type of Change
[ ] Bug Fix | [x] Enhancement | [ ] Maintenance | [ ] Refactor

## 2. Objective
To provide users with the option to convert clipboard content into either Markdown or unstyled "Clean Format" (HTML). This solves the problem of needing to strip proprietary formatting while retaining basic semantic structure when pasting into rich-text destinations.

## 3. Implementation Summary
- Refactored `src::popup.tsx` to replace the single conversion button with a split action bar containing "To Markdown" and "To Clean HTML" actions.
- Updated the clipboard processing pipeline in `src::popup.tsx` to handle requested target formats, ensuring the textarea only displays normalized Markdown while writing the generated multi-MIME payload to the system clipboard.
- Introduced `markdownToCleanHtml` functionality in `src::utils.ts` utilizing the `hast-util` and `mdast-util` AST pipelines to safely strip out unnecessary HTML bloat and styles.
- Added corresponding translation mappings (`actionToCleanHtmlBtn`, `actionToCleanHtmlTooltip`, `notifySuccessHtml`) into the locale files.

## 4. Architectural Impact & Risk
* **Performance/Security**: Expanding AST transformations via `hast` introduces minor processing overhead during the conversion step, but ensures robust sanitization of clipboard payloads. No cross-site or elevated permissions introduced.
* **Edge Cases Handled**: Fallback logic implemented to cleanly rely on the existing internal session state if valid clipboard HTML cannot be found. Safely handles empty string and un-parseable AST serialization states.

## 5. Verification
- Manual verification of UI layout for the new split action buttons.
- Confirmed clipboard clipboard payloads correctly differentiate `text/html` and `text/plain` depending on the selected conversion format.