### PR TITLE
Add GFM support for markdown table parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdclipboardext",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12",
   "type": "module",
   "scripts": {
     "dev": "tsc --sourceMap --inlineSources && vite build -c vite.popup.config.ts --sourcemap=inline && vite build -c vite.options.config.ts --sourcemap=inline",
@@ -23,6 +23,7 @@
     "mdast-util-to-hast": "^13.2.1",
     "mdast-util-to-markdown": "^2.1.2",
     "micromark-extension-directive": "^4.0.0",
+    "micromark-extension-gfm": "^3.0.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "__MSG_appDesc__",
   "permissions": ["storage", "clipboardRead", "clipboardWrite"],
   "default_locale": "en",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
   directiveFromMarkdown,
   directiveToMarkdown,
 } from "mdast-util-directive";
+import { gfm } from "micromark-extension-gfm";
 
 /**
  * Converts an HTML string to Markdown.
@@ -60,7 +61,7 @@ export function isMarkdownText(text: string): boolean {
   try {
     // Parse using the same extensions used for conversion to ensure consistency
     const tree = fromMarkdown(text, {
-      extensions: [directive()],
+      extensions: [directive(), gfm()],
       mdastExtensions: [gfmFromMarkdown(), directiveFromMarkdown()],
     });
 
@@ -134,7 +135,7 @@ export function markdownToCleanHtml(markdown: string): string {
 
   // Parse Markdown into MDAST
   const mdast = fromMarkdown(markdown, {
-    extensions: [directive()],
+    extensions: [directive(), gfm()],
     mdastExtensions: [gfmFromMarkdown(), directiveFromMarkdown()]
   });
 


### PR DESCRIPTION
## 1. Type of Change
[ ] Bug Fix | [x] Enhancement | [ ] Maintenance | [ ] Refactor

## 2. Objective
Enable full support for rendering GitHub Flavored Markdown structures (like HTML tables) within the clipboard conversion pipeline by incorporating the missing micromark GFM extension.

## 3. Implementation Summary
- Updated extension version to `1.1.12` in `package.json` and `public::manifest.json`
- Added `micromark-extension-gfm` package dependency
- Injected the `gfm()` micromark extension into the `fromMarkdown` parser in `src::utils.ts` to ensure table syntax is correctly parsed in both formatting validation and conversion logic

## 4. Architectural Impact & Risk
* **Performance/Security**: Minimal performance overhead from adding the GFM syntax parser. No security boundary changes or impact.
* **Edge Cases Handled**: Applied the GFM extension consistently to both the `isMarkdownText` verifier and `markdownToCleanHtml` generator to ensure parsing parity.

## 5. Verification
- Validated that text containing markdown tables is successfully recognized and converted cleanly to standard HTML tables.